### PR TITLE
Changed allennlp.tools to allennlp.common

### DIFF
--- a/t5/evaluation/metrics.py
+++ b/t5/evaluation/metrics.py
@@ -23,7 +23,7 @@ import collections
 
 import re
 from absl import logging
-from allennlp.tools import squad_eval
+from allennlp.common import squad_eval
 import numpy as np
 import sacrebleu
 import scipy.stats


### PR DESCRIPTION
Hi @sharannarang ,

Could you, please, consider merging this?
t5_mesh_transformer script does not run without it, as allennlp.tools package does not exist.

Thank you!
