### PR TITLE
Ensure deterministic order in Mixture.get_dataset(..., shuffle=False)

### DIFF
--- a/t5/data/utils.py
+++ b/t5/data/utils.py
@@ -939,7 +939,8 @@ class Mixture(DatasetProviderBase):
         for task in tasks]
     rates = [self.get_rate(task) for task in tasks]
     # Sample from the dataset with the rates rates
-    dataset = tf.data.experimental.sample_from_datasets(datasets, rates)
+    seed = None if shuffle else 42
+    dataset = tf.data.experimental.sample_from_datasets(datasets, rates, seed)
     if (split == "train" and use_cached and
         all(t.supports_caching for t in tasks)):
       _log_mixing_proportions(tasks, datasets, rates, dataset, sequence_length,


### PR DESCRIPTION
Currently, using Mixture of a few datasets with Estimator.evaluate or tf.estimator.train_and_evaluate results in jittery results. That's because Mixture.get_dataset uses sample_from_datasets, which returns a dataset in non-deterministic order even when shuffle=False. This PR solves it by fixing an operation-level seed for sample_from_datasets when shuffle=False.

Motivation for using Estimator.evaluate instead of MtfModel.eval: the latter function only works with token-level metrics and doesn't provide access to logits. It makes it impossible to e.g., evaluate perplexity — and perplexity works better than accuracy for certain tasks were T5 could excel otherwise.