### PR TITLE
[WIP] Add Model class for Hugging Face Transformers T5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ setuptools.setup(
         'six>=1.14',  # TODO(adarob): Remove once rouge-score is updated.
         'tensorflow-text',
         'tfds-nightly',
+        'torch',
+        'transformers>=2.7.0',
     ],
     extras_require={
         'gcp': ['gevent', 'google-api-python-client', 'google-compute-engine',

--- a/t5/models/__init__.py
+++ b/t5/models/__init__.py
@@ -16,3 +16,4 @@
 
 import t5.models.mesh_transformer
 from t5.models.mtf_model import MtfModel
+from t5.models.hf_model import HfPyTorchModel

--- a/t5/models/hf_model.py
+++ b/t5/models/hf_model.py
@@ -193,6 +193,8 @@ class HfPyTorchModel(T5Model):
     """
     self._model.train()
     ds = get_dataset(mixture_or_task_name, sequence_length, split, batch_size)
+    # Repeat dataset forever
+    ds = itertools.cycle(ds)
     optimizer = optimizer(self._model.parameters())
     if learning_rate_scheduler:
       learning_rate_scheduler = learning_rate_scheduler(optimizer)

--- a/t5/models/hf_model.py
+++ b/t5/models/hf_model.py
@@ -21,6 +21,7 @@ import os
 import re
 import time
 
+from absl import logging
 import mesh_tensorflow.transformer.dataset as transformer_dataset
 import t5.data
 from t5.models.t5_model import T5Model
@@ -128,7 +129,7 @@ class HfPyTorchModel(T5Model):
     """
     model_dir = model_dir or self._model_dir
     path = os.path.join(model_dir, CHECKPOINT_FILE_FORMAT.format(step))
-    tf.logging.info("Loading from %s", path)
+    logging.info("Loading from %s", path)
     self._model.load_state_dict(torch.load(path))
     self._step = step
 
@@ -201,7 +202,7 @@ class HfPyTorchModel(T5Model):
 
         if not train_step % save_steps:
           # TODO(craffel): Consider saving optimizer and scheduler state.
-          tf.logging.info(f"Saving checkpoint for step {self._step}")
+          logging.info(f"Saving checkpoint for step {self._step}")
           self.save_checkpoint(self._step)
 
         self._model.zero_grad()
@@ -279,7 +280,7 @@ class HfPyTorchModel(T5Model):
 
     for task in tasks:
       if split not in task.splits:
-        tf.logging.info(
+        logging.info(
             "Task {task.name} has no '{split}' split; skipping eval."
         )
     tasks = [task for task in tasks if split in task.splits]
@@ -359,7 +360,7 @@ class HfPyTorchModel(T5Model):
           for metric_name, metric_value in scores.items():
             tag = f"eval/{task.name}/{metric_name}"
             self._writer.add_scalar(tag, metric_value, self._step)
-            tf.logging.info(
+            logging.info(
                 "%s at step %d: %.3f", tag, self._step, metric_value
             )
 

--- a/t5/models/hf_model.py
+++ b/t5/models/hf_model.py
@@ -216,7 +216,9 @@ class HfPyTorchModel(T5Model):
         if learning_rate_scheduler:
           learning_rate_scheduler.step()
 
-        self._writer.add_scalar("loss", loss.detach().numpy(), self._step)
+        self._writer.add_scalar(
+            "loss", loss.detach().cpu().numpy(), self._step
+        )
         self._writer.add_scalar("step/s", 1 / (time.time() - now), self._step)
         now = time.time()
         self._step += 1
@@ -334,7 +336,7 @@ class HfPyTorchModel(T5Model):
           predicted_tokens = self._model.generate(
               input_ids=self.to_tensor(batch["inputs"]), **generate_kwargs
           )
-          predicted_tokens = predicted_tokens.numpy().tolist()
+          predicted_tokens = predicted_tokens.cpu().numpy().tolist()
           predictions.extend(
               [
                   task.postprocess_fn(vocab.decode(p), example=ex)

--- a/t5/models/hf_model.py
+++ b/t5/models/hf_model.py
@@ -331,6 +331,7 @@ class HfPyTorchModel(T5Model):
         cached_examples[task.name] = batches
 
     def _eval_current_model():
+      self._model.eval()
       for task in tasks:
         ds = cached_examples[task.name]
         targets = cached_targets[task.name]

--- a/t5/models/hf_model.py
+++ b/t5/models/hf_model.py
@@ -1,0 +1,412 @@
+# Copyright 2020 The T5 Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Hugging Face Transformers T5 Model."""
+
+import functools
+import itertools
+import os
+import re
+import time
+
+import mesh_tensorflow.transformer.dataset as transformer_dataset
+import t5.data
+from t5.models.t5_model import T5Model
+import tensorflow as tf
+import tensorflow_datasets as tfds
+import torch
+import torch.utils.tensorboard
+import transformers
+
+CHECKPOINT_FILE_FORMAT = "model-{}.checkpoint"
+
+
+def get_dataset(mixture_or_task_name, sequence_length, split, batch_size):
+  """Get a generator of numpy examples for a given Task or Mixture.
+
+  Args:
+    mixture_or_task_name: str, the name of the Mixture or Task to train on.
+      Must be pre-registered in the global `t5.data.TaskRegistry` or
+      `t5.data.MixtureRegistry.`
+    sequence_length: dict of int, a dict mapping feature name to length.
+    split: str or `tensorflow_datasets.Split`, the data split to load.
+    batch_size: int, the number of padded sequences in each batch.
+  """
+  task = t5.data.get_mixture_or_task(mixture_or_task_name)
+  ds = task.get_dataset(sequence_length, split)
+
+  ds = transformer_dataset.pack_or_pad(
+      ds,
+      sequence_length,
+      pack=False,
+      feature_keys=tuple(task.output_features),
+      ensure_eos=True,
+  )
+
+  def _add_attention_masks(ds, feature_keys):
+
+    def _map_fn(ex):
+      for key in feature_keys:
+          tensor = ex[key]
+          mask = tf.cast(tf.greater(tensor, 0), tensor.dtype)
+          ex[key + "_mask"] = mask
+      return ex
+
+    return ds.map(
+        _map_fn,
+        num_parallel_calls=t5.data.preprocessors.num_parallel_calls()
+    )
+
+  ds = _add_attention_masks(ds, tuple(task.output_features))
+  ds = ds.batch(batch_size, drop_remainder=False)
+  return tfds.as_numpy(ds)
+
+
+class HfPyTorchModel(T5Model):
+  """Wrapper class for Hugging Face Transformers PyTorch T5 model."""
+
+  def __init__(self, model_spec, model_dir, device):
+    """Constructor for HfModel class.
+
+    Args:
+      model_spec: A str to pass into the `pretrained_model_name_or_path`
+        argument of `transformers.T5ForConditionalGeneration.from_pretrained`
+        (e.g. `"t5-base"` or a path to a previously trained model) or an
+        instance of the `transformers.configuration_t5.T5Config` class to use
+        to directly construct the `transformers.T5ForConditionalGeneration`
+        object.
+      model_dir: str, directory to save and load model checkpoints.
+      device: `torch.device` on which the model should be run.
+    """
+    if isinstance(model_spec, str):
+      self._model = transformers.T5ForConditionalGeneration.from_pretrained(
+          model_spec
+      )
+    elif isinstance(model_spec, transformers.T5Config):
+      self._model = transformers.T5ForConditionalGeneration(model_spec)
+    else:
+      raise ValueError("model_spec should be a string or T5Config.")
+
+    tf.io.gfile.makedirs(model_dir)
+    self._writer = torch.utils.tensorboard.writer.SummaryWriter(model_dir)
+    self._model_dir = model_dir
+    self._device = device
+    if self._device.type == "cuda":
+      self._model.cuda()
+    self._step = 0
+    self.load_latest_checkpoint()
+    self.to_tensor = functools.partial(torch.as_tensor, device=self._device)
+
+  def save_checkpoint(self, step):
+    """Save the current model parameters to the `model_dir`.
+
+    Args:
+      step: int, the current training step.
+    """
+    path = os.path.join(self._model_dir, CHECKPOINT_FILE_FORMAT.format(step))
+    torch.save(self._model.state_dict(), path)
+
+  def load_checkpoint(self, step, model_dir=None):
+    """Load the model parameters from a checkpoint at a given step.
+
+    Args:
+      step: int, load the checkpoint from this training step.
+      model_dir: str, the directory of the checkpoint to load or None to use
+        this model's directory.
+    """
+    model_dir = model_dir or self._model_dir
+    path = os.path.join(model_dir, CHECKPOINT_FILE_FORMAT.format(step))
+    tf.logging.info("Loading from %s", path)
+    self._model.load_state_dict(torch.load(path))
+    self._step = step
+
+  def get_latest_checkpoint_step(self, model_dir=None):
+    """Retrieve the step corresponding to the most recent checkpoint.
+
+    Args:
+      model_dir: str, the directory of the checkpoint to load or None to use
+        this model's directory.
+
+    Returns:
+      An integer corresponding to the most recent step, or None if there are no
+      checkpoints in the model directory.
+    """
+    model_dir = model_dir or self._model_dir
+    checkpoint_files = tf.io.gfile.glob(
+        os.path.join(model_dir, CHECKPOINT_FILE_FORMAT.format("*"))
+    )
+    if not checkpoint_files:
+      return
+    step_regex = re.compile(".*" + CHECKPOINT_FILE_FORMAT.format(r"(\d+)"))
+    steps = [int(step_regex.match(path).group(1)) for path in checkpoint_files]
+    return max(steps)
+
+  def load_latest_checkpoint(self):
+    """Load the most recent checkpoint and update the model's current step."""
+    latest_step = self.get_latest_checkpoint_step()
+    if latest_step is not None:
+      self.load_checkpoint(latest_step)
+
+  def train(
+      self,
+      mixture_or_task_name,
+      steps,
+      save_steps,
+      sequence_length,
+      split,
+      batch_size,
+      optimizer,
+      learning_rate_scheduler=None,
+  ):
+    """Train the model on the given Mixture or Task.
+
+    Args:
+      mixture_or_task_name: str, the name of the Mixture or Task to train on.
+        Must be pre-registered in the global `t5.data.TaskRegistry` or
+        `t5.data.MixtureRegistry.`
+      steps: int, the total number of steps to train for.
+      save_steps: int, the number of steps between checkpoint saves.
+      sequence_length: dict of int, a dict mapping feature name to length.
+      split: str or `tensorflow_datasets.Split`, the data split to load.
+      batch_size: int, the number of padded sequences in each batch.
+      optimizer: function that takes the model parameters as its sole argument.
+        For example, to use an AdamW optimizer with a learning rate of 1e-4,
+        you could pass in `functools.partial(transformers.AdamW, lr=1e-4)`.
+      learning_rate_scheduler: optional function that takes in an optimizer as
+        its sole argument. For example, to use a schedule that warms up the
+        optimizer's learning rate after 100 steps, you could pass in
+        `functools.partial(transformers.get_constant_schedule_with_warmup,
+       num_warmup_steps=100)`.
+    """
+    self._model.train()
+    ds = get_dataset(mixture_or_task_name, sequence_length, split, batch_size)
+    optimizer = optimizer(self._model.parameters())
+    if learning_rate_scheduler:
+      learning_rate_scheduler = learning_rate_scheduler(optimizer)
+
+    now = time.time()
+    for train_step, batch in enumerate(itertools.islice(ds, steps)):
+
+        if not train_step % save_steps:
+          # TODO(craffel): Consider saving optimizer and scheduler state.
+          tf.logging.info(f"Saving checkpoint for step {self._step}")
+          self.save_checkpoint(self._step)
+
+        self._model.zero_grad()
+        loss, _, _ = self._model(
+            input_ids=self.to_tensor(batch["inputs"]),
+            attention_mask=self.to_tensor(batch["inputs_mask"]),
+            decoder_attention_mask=self.to_tensor(batch["targets_mask"]),
+            lm_labels=self.to_tensor(batch["targets"]),
+        )
+        loss.backward()
+        optimizer.step()
+        if learning_rate_scheduler:
+          learning_rate_scheduler.step()
+
+        self._writer.add_scalar("loss", loss.detach().numpy(), self._step)
+        self._writer.add_scalar("step/s", 1 / (time.time() - now), self._step)
+        now = time.time()
+        self._step += 1
+
+  def eval(
+      self,
+      mixture_or_task_name,
+      checkpoint_steps=None,
+      summary_dir=None,
+      split="validation",
+      sequence_length=None,
+      batch_size=None,
+      **generate_kwargs,
+  ):
+    """Evaluate the model on the given Mixture or Task.
+
+    *Note*: If a checkpoint step is provided (i.e. `checkpoint_steps is not
+    None`), the model's state will be replaced by the state in those
+    checkpoints. If you have not saved your model before calling `eval`, you
+    should call `save_checkpoint` before `eval` to avoid losing its parameter
+    values and state.
+
+    Args:
+      mixture_or_task_name: str, the name of the Mixture or Task to evaluate
+        on.  Must be pre-registered in the global `t5.data.TaskRegistry` or
+        `t5.data.MixtureRegistry.`
+      checkpoint_steps: int, list of ints, or None. If None, eval in the model
+        in its current state without loading any checkpoints. If an int or list
+        of ints, evaluation will be run on the checkpoint files in `model_dir`
+        whose global steps are those provided. If -1, eval on the latest
+        checkpoint from the model directory.
+      summary_dir: str, path to write TensorBoard events file summaries for
+        eval. If None, use model_dir/{split}_eval.
+      split: str, the mixture/task split to evaluate on.
+      sequence_length: dict of int, a dict mapping feature name to length.
+    batch_size: int, the number of padded sequences in each batch.
+      **generate_kwargs: Additional keyword arguments to pass to
+        `transformers.PretrainedModel.generate()`, for example to change the
+        decoding strategy. See the documentation for
+        `transformers.PretrainedModel.generate()` for options.
+    """
+    # We are forced to provide a default for sequence_length and batch_size if
+    # we want to have defaults for the required `T5Model.eval` arguments .
+    if sequence_length is None:
+      raise ValueError("A sequence_length must be provided for eval.")
+    if batch_size is None:
+      raise ValueError("A batch_size must be provided for eval.")
+
+    mixture_or_task = t5.data.get_mixture_or_task(mixture_or_task_name)
+    vocab = t5.data.sentencepiece_vocabulary.SentencePieceVocabulary(
+        mixture_or_task.sentencepiece_model_path
+    )
+
+    if isinstance(mixture_or_task, t5.data.Mixture):
+      tasks = mixture_or_task.tasks
+    elif isinstance(mixture_or_task, t5.data.Task):
+      tasks = [mixture_or_task]
+
+    for task in tasks:
+      if split not in task.splits:
+        tf.logging.info(
+            "Task {task.name} has no '{split}' split; skipping eval."
+        )
+    tasks = [task for task in tasks if split in task.splits]
+
+    summary_dir = summary_dir or os.path.join(self._model_dir, f"{split}_eval")
+    tf.io.gfile.makedirs(summary_dir)
+
+    def _write_lines_to_file(lines, filename):
+      """Write each line to a filename, replacing the file if it exists."""
+      if tf.io.gfile.exists(filename):
+        tf.io.gfile.remove(filename)
+      with tf.io.gfile.GFile(filename, "w") as output_file:
+        output_file.write("\n".join([str(l) for l in lines]))
+
+    def _unbatch(batch):
+      """Converts a dict of lists to a list of dicts of singletons."""
+      return [dict(zip(batch, t)) for t in zip(*batch.values())]
+
+    # Pre-load in all of the targets once before doing eval
+    cached_targets = {}
+    cached_examples = {}
+    for task in tasks:
+      if task.metric_fns:
+        ds = get_dataset(task.name, sequence_length, split, batch_size)
+        # Create list of postprocessed text targets
+        batches = list(ds)
+        if not batches:
+          raise ValueError(f"The '{split}' split of {task.name} is empty.")
+        # "Unbatch" the dataset
+        examples = [ex for b in batches for ex in _unbatch(b)]
+        targets = [
+            task.postprocess_fn(
+                tf.compat.as_text(ex["targets_plaintext"]),
+                example=ex,
+                is_target=True
+            ) for ex in examples
+        ]
+        targets_filename = os.path.join(summary_dir, f"{task.name}_targets")
+        _write_lines_to_file(targets, targets_filename)
+
+        inputs_filename = os.path.join(summary_dir, f"{task.name}_inputs")
+        inputs = [ex["inputs_plaintext"] for ex in examples]
+        _write_lines_to_file(inputs, inputs_filename)
+
+        cached_targets[task.name] = targets
+        cached_examples[task.name] = batches
+
+    def _eval_current_model():
+      for task in tasks:
+        ds = cached_examples[task.name]
+        targets = cached_targets[task.name]
+        predictions = []
+        for batch in ds:
+          predicted_tokens = self._model.generate(
+              input_ids=self.to_tensor(batch["inputs"]), **generate_kwargs
+          )
+          predicted_tokens = predicted_tokens.numpy().tolist()
+          predictions.extend(
+              [
+                  task.postprocess_fn(vocab.decode(p), example=ex)
+                  for p, ex in zip(predicted_tokens, _unbatch(batch))
+              ]
+          )
+
+        if len(targets) != len(predictions):
+          raise ValueError(
+              f"#targets ({len(targets)}) != #predictions ({len(predictions)})"
+          )
+
+        predictions_file = os.path.join(
+            summary_dir, f"{task.name}_{self._step}_predictions"
+        )
+        _write_lines_to_file(predictions, predictions_file)
+
+        for metric_fn in task.metric_fns:
+          scores = metric_fn(targets, predictions)
+          for metric_name, metric_value in scores.items():
+            tag = f"eval/{task.name}/{metric_name}"
+            self._writer.add_scalar(tag, metric_value, self._step)
+            tf.logging.info(
+                "%s at step %d: %.3f", tag, self._step, metric_value
+            )
+
+        self._writer.flush()
+
+    if checkpoint_steps is None:
+      _eval_current_model()
+      return
+    elif isinstance(checkpoint_steps, int):
+      checkpoint_steps = [checkpoint_steps]
+    elif not isinstance(checkpoint_steps, (list, tuple)):
+      raise ValueError(
+          f"checkpoint_steps must be None, int or list; got {checkpoint_steps}"
+      )
+    for checkpoint_step in checkpoint_steps:
+      self.load_checkpoint(checkpoint_step)
+      _eval_current_model()
+
+  def finetune(
+      self,
+      mixture_or_task_name,
+      finetune_steps,
+      pretrained_model_dir,
+      pretrained_checkpoint_step=-1,
+      **train_kwargs,
+  ):
+    """Trains model after loading from any existing checkpoint.
+
+    Note that if you have initialized the model using a pre-trained model
+    specification (e.g. by passing "t5-base" for `model_spec`) then you can
+    just call `train` directly. This function is only provided for convenience
+    for loading a pre-trained model checkpoint from an arbitrary model
+    directory before calling `train`.
+
+    Args:
+      mixture_or_task_name: str, the name of the Mixture or Task to evaluate
+        on.  Must be pre-registered in the global `t5.data.TaskRegistry` or
+        `t5.data.MixtureRegistry.`
+      finetune_steps: int, the number of additional steps to train for.
+      pretrained_model_dir: str, directory with pretrained model checkpoints.
+      pretrained_checkpoint_step: int, checkpoint to initialize weights from.
+        If -1 (default), use the latest checkpoint from the pretrained model
+        directory.
+      **train_kwargs: Additional keyword arguments to pass to `train`. See the
+        docstring for `train` for more details.
+    """
+    if pretrained_checkpoint_step == -1:
+      pretrained_checkpoint_step = self.get_latest_checkpoint_step(
+          pretrained_model_dir
+      )
+    self.load_checkpoint(pretrained_checkpoint_step, pretrained_model_dir)
+    self.train(mixture_or_task_name, finetune_steps, **train_kwargs)

--- a/t5/models/hf_model.py
+++ b/t5/models/hf_model.py
@@ -336,10 +336,8 @@ class HfPyTorchModel(T5Model):
         now = time.time()
         self._step += 1
 
-    # Save a final checkpoint step if we didn't just save one
-    if train_step % save_steps:
-      logging.info(f"Saving final checkpoint for step {self._step}")
-      self.save_checkpoint(self._step)
+    logging.info(f"Saving final checkpoint for step {self._step}")
+    self.save_checkpoint(self._step)
 
   def eval(
       self,

--- a/t5/models/t5_model.py
+++ b/t5/models/t5_model.py
@@ -24,19 +24,17 @@ class T5Model(object):
   __metaclass__ = abc.ABCMeta
 
   @abc.abstractmethod
-  def train(self, mixture_or_task_name, steps):
+  def train(self):
     raise NotImplementedError()
 
   @abc.abstractmethod
-  def eval(self, mixture_or_task_name, checkpoint_steps, summary_dir, split):
+  def eval(self):
     raise NotImplementedError()
 
   @abc.abstractmethod
-  def predict(self, input_file, output_file, checkpoint_steps, beam_size,
-              temperature):
+  def predict(self):
     raise NotImplementedError()
 
   @abc.abstractmethod
-  def finetune(self, mixture_or_task_name, finetune_steps, pretrained_model_dir,
-               pretrained_checkpoint_step):
+  def finetune(self):
     raise NotImplementedError()


### PR DESCRIPTION
Currently experimental, use at your own risk!

[Here](https://gist.github.com/craffel/cb62f4d5787cda1837dc7fe2e3f35d03) is an example showing fine-tuning T5-Base on CoLA. It gets to ~62% accuracy after 5000 steps. I think we got 63% with Mesh TensorFlow at some point, but that was saving checkpoints more often and also training for a lot longer. This example also uses a different optimizer (so we can't reuse pretraining optimizer state). Given all of that I would definitely call the Hugging Face pipeline ready-to-go for fine-tuning (though it will never be useful for exactly replicating our results).

TODO:
- [x] Make `predict` take list of strings or files
- [x] Add `predict` method
- [x] Remove args from base `Model` class functions and reorder
- [x] Save a checkpoint at the end of training
- [x] Add option for evaluating all checkpoints
- [x] Add example code
- [x] Add `transformers` as a library dep
- [x] Add private getters for model and step