### PR TITLE
do not filter position features

### DIFF
--- a/t5/data/utils.py
+++ b/t5/data/utils.py
@@ -1012,7 +1012,8 @@ class Mixture(DatasetProviderBase):
     if not tasks:
       raise ValueError("No datasets have a '{}' split".format(split))
     def filter_features(ex):
-      return {k: v for k, v in ex.items() if k in self.output_features}
+      return {k: v for k, v in ex.items()
+              if k in self.output_features or re.sub(r"_position$", "", k) in self.output_features}
     datasets = [
         task.get_dataset(sequence_length, split, use_cached, shuffle=shuffle)  # pylint:disable=g-complex-comprehension
         .repeat()


### PR DESCRIPTION
In response to #325. To be able to specify custom positions for an example do not filter features ending with `_position` and starting with a feature name in `output_features`.