### PR TITLE
Fix bug causing unsupported operand type error.

### DIFF
--- a/t5/seqio/vocabularies.py
+++ b/t5/seqio/vocabularies.py
@@ -56,7 +56,7 @@ class Vocabulary(metaclass=abc.ABCMeta):
       use_eos: Whether to stop decoding at EOS_ID=1.
       use_unk: Whether to replace tokens out of range with UNK_ID=2.
     """
-    self._extra_ids = extra_ids
+    self._extra_ids = extra_ids or 0
     self._use_eos = use_eos
     self._use_unk = use_unk
 


### PR DESCRIPTION
SentencePieceVocabulary extra_ids' default is None, and it gets passed up to the base class, which used to get initialized with None and not its default value (0).

Should fix [this](https://github.com/google-research/multilingual-t5/issues/48).