### PR TITLE
fix: typo spelling grammar

### DIFF
--- a/t5/models/gin/objectives/README
+++ b/t5/models/gin/objectives/README
@@ -2,7 +2,7 @@ This directory contains configurations for unsupervised training objectives.
 
 Naming conventions:
 
-Most files follow the follwing naming scheme:
+Most files follow the following naming scheme:
 
 <noise-pattern>_<noise-density-percentage>_<inputs-encoding>_<targets-encoding>
 

--- a/t5/models/mesh_transformer_main.py
+++ b/t5/models/mesh_transformer_main.py
@@ -176,7 +176,7 @@ def main(_):
           mesh_transformer.DEPRECATED_GIN_REFERENCES +
           tuple(FLAGS.additional_deprecated_gin_references))),
       finalize_config=False)
-  # We must overide this binding explicitly since it is set to a deprecated
+  # We must overidde this binding explicitly since it is set to a deprecated
   # function or class in many existing configs.
   gin.bind_parameter("run.vocabulary", mesh_transformer.get_vocabulary())
   gin.finalize()


### PR DESCRIPTION
## description
hello !
fix typo on docs and commented code, and replace to correct words

## testing
testing not included because just replace the typo with correct one