### PR TITLE
Output raw model outputs during eval

### DIFF
--- a/t5/models/utils.py
+++ b/t5/models/utils.py
@@ -347,14 +347,18 @@ def run_eval(
           for d, ex in zip(outputs[:dataset_size], tfds.as_numpy(dataset))
       ]
 
-      # Remove the used decodes.
-      del outputs[:dataset_size]
-
       if summary_dir:
+        outputs_filename = os.path.join(
+            summary_dir,
+            "{}_{}_outputs".format(task.name, step))
+        write_lines_to_file(outputs[:dataset_size], outputs_filename)
         predictions_filename = os.path.join(
             summary_dir,
             "{}_{}_predictions".format(task.name, step))
         write_lines_to_file(predictions, predictions_filename)
+
+      # Remove the used decodes.
+      del outputs[:dataset_size]
 
       with tf.Graph().as_default():
         if summary_dir:


### PR DESCRIPTION
Currently, only the postprocessed model outputs are written out into a file suffixed with "predictions". This outputs an additional file suffixed with "outputs" that stores the raw model outputs, without postprocessing.