### PR TITLE
Fix `hf_model` script according to the current Hugging Face signature for `T5ForConditionalGeneration`

### DIFF
--- a/t5/models/hf_model.py
+++ b/t5/models/hf_model.py
@@ -209,7 +209,7 @@ class HfPyTorchModel(T5Model):
       self._model.cuda()
     self._step = 0
     self.load_latest_checkpoint()
-    self.to_tensor = functools.partial(torch.as_tensor, device=self._device)
+    self.to_tensor = functools.partial(torch.as_tensor, device=self._device, dtype=torch.long)
 
   @property
   def model(self):
@@ -339,7 +339,7 @@ class HfPyTorchModel(T5Model):
           input_ids=self.to_tensor(batch["inputs"]),
           attention_mask=self.to_tensor(batch["inputs_mask"]),
           decoder_attention_mask=self.to_tensor(batch["targets_mask"]),
-          lm_labels=self.to_tensor(batch["targets"]),
+          labels=self.to_tensor(batch["targets"]),
       )
       loss = outputs[0]
       loss.backward()

--- a/t5/models/hf_model.py
+++ b/t5/models/hf_model.py
@@ -27,6 +27,7 @@ Usage example for fine-tuning and evaluating on CoLA:
 import functools
 
 import t5
+import t5.models
 import torch
 import transformers
 


### PR DESCRIPTION
I've fixed the `HfPyTorchModel` so that it works according to the Hugging Face API:

1. Changed the dtype to `torch.LongTensor` in the `to_tensor` function.
2. Changed the parameter `lm_labels` to `labels` in the forward function of the model in the `train` method of  `HfPyTorchModel`.

I've also fixed the example stated at the beginning of the script, that currently didn't work.