### PR TITLE
Upgrade GLUE Version to 2.0.0

### DIFF
--- a/t5/data/tasks.py
+++ b/t5/data/tasks.py
@@ -145,7 +145,7 @@ for b in tfds.text.glue.Glue.builder_configs.values():
   TaskRegistry.add(
       "glue_%s_v002" % b.name,
       source=seqio.TfdsDataSource(
-          tfds_name="glue/%s:1.0.0" % b.name,
+          tfds_name="glue/%s:2.0.0" % b.name,
           splits=["test"] if b.name == "ax" else None),
       preprocessors=[
           get_glue_text_preprocessor(b),


### PR DESCRIPTION
GLUE 1.0.0 was causing errors with TFDS as it is outdated. Upgrading to 2.0.0 fixed the issue. 

`ValueError: The version of the dataset you are trying to use (glue/cola/1.0.0) is too old for this version of TFDS so cannot be generated.Either sync to a previous version of TFDS to first prepare the data or use another version of the dataset. Available for `download_and_prepare`: ['2.0.0']`